### PR TITLE
Update pod to newest version that can be built with Swift 5.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-algolia",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Nativescript plugin for Algolia(https://www.algolia.com/) search",
     "main": "index.js",
     "typings": "index.d.ts",

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,9 +1,1 @@
-pod 'AlgoliaSearch-Client-Swift', '~> 5.0'
-
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['SWIFT_VERSION'] = '4.0'
-    end
-  end
-end
+pod 'InstantSearchClient', '~> 7.0'


### PR DESCRIPTION
More permanent solution to build failures related to Swift versions. My project requires other plugins to built with Swift 5 and can no longer use `export SWIFT_VERSION=4`. Updated the pod to the newest version of the Algolia search `InstantSearchClient`. Seems to work correctly right out of the box.